### PR TITLE
Unicode fix

### DIFF
--- a/src/content/splash.js
+++ b/src/content/splash.js
@@ -80,7 +80,7 @@ var splash = {
 
             splashTxt.setAttribute("style", prefBranch.getCharPref("textStyle") + txColor);
 
-            var textOverride = prefBranch.getCharPref("textOverride");
+            var textOverride = prefBranch.getComplexValue("textOverride", Components.interfaces.nsISupportsString).data;
             if (textOverride) {
                 textOverride = textOverride.replace(/{appVersion}/ig, Services.appinfo.version);
                 textOverride = textOverride.replace(/{buildID}/ig, Services.appinfo.appBuildID);

--- a/src/content/splash.js
+++ b/src/content/splash.js
@@ -80,7 +80,7 @@ var splash = {
 
             splashTxt.setAttribute("style", prefBranch.getCharPref("textStyle") + txColor);
 
-            var textOverride = prefBranch.getComplexValue("textOverride", Components.interfaces.nsISupportsString).data;
+            var textOverride = prefBranch.getComplexValue("textOverride", Ci.nsISupportsString).data;
             if (textOverride) {
                 textOverride = textOverride.replace(/{appVersion}/ig, Services.appinfo.version);
                 textOverride = textOverride.replace(/{buildID}/ig, Services.appinfo.appBuildID);


### PR DESCRIPTION
Non-ASCII text was wrongly interpreted as simple one-byte.
Fixed using magic of [`getComplexValue()`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIPrefBranch#getComplexValue()).